### PR TITLE
Fix nano-modeline-org-clock-mode-p

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -505,7 +505,7 @@ depending on the version of mu4e."
 
 (defun nano-modeline-org-clock-mode-p ()
   (and (boundp 'org-mode-line-string)
-       (not org-mode-line-string)))
+       (stringp org-mode-line-string)))
 
 (defun nano-modeline-org-clock-mode ()
     (let ((buffer-name (format-mode-line "%b"))


### PR DESCRIPTION
Thanks for creating this as a separate package!

I think there's small mistake in `nano-modeline-org-clock-mode-p`.

If `org-mode-line-string` holds the currently clocked task, then `(not org-mode-line-string)` is `nil`, which is the exact opposite of what we want, right?