### PR TITLE
Override mu4e~header-line-format to nil when modeline is on bottom

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -740,7 +740,9 @@ depending on the version of mu4e."
     (setq eshell-status-in-mode-line nil))
 
   (with-eval-after-load 'mu4e
-    (advice-add 'mu4e~header-line-format :override #'nano-modeline))
+    (if (eq nano-modeline-position 'top)
+        (advice-add 'mu4e~header-line-format :override #'nano-modeline)
+      (advice-add 'mu4e~header-line-format :override #'(lambda () nil))))
 
   (if (eq nano-modeline-position 'top)
       (setq Info-use-header-line nil))


### PR DESCRIPTION
Shouldn't the header-line only be overwritten with the nano-modeline if `nano-modeline-position` is `'top` and otherwise it should be `nil`? Not sure at all if this is the right way to do it though.