### PR TITLE
term is required when compiling

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -67,6 +67,9 @@
 ;;
 
 ;;; Code:
+(eval-when-compile
+  (require 'term))
+
 (defgroup nano nil
   "N Λ N O"
   :group 'convenience)


### PR DESCRIPTION
Allows term-in-char-mode to be expanded at compile time so that it can be called
without requiring term. Necessary for vterm modeline to work if term isn't required elsewhere