### PR TITLE
Option for current tab number to secondary section

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -24,7 +24,7 @@
 ;; see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
-;; 
+;;
 ;; Nano modeline is a minor mode that modify the modeline as:
 ;; [ name (primary)                      secondary ]
 ;;
@@ -241,97 +241,97 @@ Then count is provided by `nano-modeline-email-count'."
 
     (imenu-list-mode        :mode-p nano-modeline-imenu-list-mode-p
                             :format nano-modeline-imenu-list-mode
-                            :icon "") ;; nerd-font / oct-three-bars
+                            :icon " ") ;; nerd-font / oct-three-bars
     (org-capture-mode       :mode-p nano-modeline-org-capture-mode-p
                             :format nano-modeline-org-capture-mode
                             :on-activate nano-modeline-org-capture-activate
                             :on-inactivate nano-modeline-org-capture-inactivate
-                            :icon "") ;; nerd-font / oct-calendar
+                            :icon " ") ;; nerd-font / oct-calendar
 
     (prog-mode              :mode-p nano-modeline-prog-mode-p
                             :format nano-modeline-prog-mode
-                            :icon "") ;; nerd-font / oct-file-code
+                            :icon " ") ;; nerd-font / oct-file-code
     (mu4e-compose-mode      :mode-p nano-modeline-mu4e-compose-mode-p
                             :format nano-modeline-mu4e-compose-mode
-                            :icon "") ;; nerd-font / oct-pencil
+                            :icon " ") ;; nerd-font / oct-pencil
     (mu4e-headers-mode      :mode-p nano-modeline-mu4e-headers-mode-p
                             :format nano-modeline-mu4e-headers-mode
-                            :icon "") ;; nerd-font / oct-search
+                            :icon " ") ;; nerd-font / oct-search
     (mu4e-loading-mode      :mode-p nano-modeline-mu4e-loading-mode-p
                             :format nano-modeline-mu4e-loading-mode
-                            :icon "") ;; nerd-font / oct-gears
+                            :icon " ") ;; nerd-font / oct-gears
     (mu4e-main-mode         :mode-p nano-modeline-mu4e-main-mode-p
                             :format nano-modeline-mu4e-main-mode
-                            :icon "") ;; nerd-font / oct-inbox
+                            :icon " ") ;; nerd-font / oct-inbox
     (mu4e-view-mode         :mode-p nano-modeline-mu4e-view-mode-p
                             :format nano-modeline-mu4e-view-mode
-                            :icon "") ;; nerd-font / oct-comment
+                            :icon " ") ;; nerd-font / oct-comment
     (mu4e-dashboard-mode    :mode-p nano-modeline-mu4e-dashboard-mode-p
                             :format nano-modeline-mu4e-dashboard-mode
-                            :icon "") ;; nerd-font / oct-inbox
+                            :icon " ") ;; nerd-font / oct-inbox
     (messages-mode          :mode-p nano-modeline-messages-mode-p
                             :format nano-modeline-messages-mode
-                            :icon "") ;; nerd-font / oct-comment
+                            :icon " ") ;; nerd-font / oct-comment
     (text-mode              :mode-p nano-modeline-text-mode-p
                             :format nano-modeline-text-mode
-                            :icon "") ;; nerd-font / oct-file-text
+                            :icon " ") ;; nerd-font / oct-file-text
     (term-mode              :mode-p nano-modeline-term-mode-p
                             :format nano-modeline-term-mode
-                            :icon "") ;; nerd-font / oct-term
+                            :icon " ") ;; nerd-font / oct-term
     (vterm-mode             :mode-p nano-modeline-vterm-mode-p
                             :format nano-modeline-term-mode
-                            :icon "") ;; nerd-font / oct-term
+                            :icon " ") ;; nerd-font / oct-term
     (buffer-menu-mode       :mode-p nano-modeline-buffer-menu-mode-p
                             :format nano-modeline-buffer-menu-mode
                             :on-activate nano-modeline-buffer-menu-activate
                             :on-inactivate nano-modeline-buffer-menu-inactivate
-                            :icon "") ;; nerd-font / oct-three-bars
+                            :icon " ") ;; nerd-font / oct-three-bars
 
     (calendar-mode          :mode-p nano-modeline-calendar-mode-p
                             :format nano-modeline-calendar-mode
                             :on-activate nano-modeline-calendar-activate
                             :on-inactivate nano-modeline-calendar-inactivate
-                            :icon "") ;; nerd-font / oct-calendar
+                            :icon " ") ;; nerd-font / oct-calendar
     (completion-list-mode   :mode-p nano-modeline-completion-list-mode-p
                             :format nano-modeline-completion-list-mode
-                            :icon "") ;; nerd-font / oct-list-unordered
+                            :icon " ") ;; nerd-font / oct-list-unordered
     (deft-mode              :mode-p nano-modeline-deft-mode-p
                             :format nano-modeline-deft-mode
-                            :icon "") ;; nerd-font / oct-search
+                            :icon " ") ;; nerd-font / oct-search
     (doc-view-mode          :mode-p nano-modeline-doc-view-mode-p
                             :format nano-modeline-doc-view-mode
-                            :icon "") ;; nerd-font / oct-
+                            :icon " ") ;; nerd-font / oct-
     (elfeed-search-mode     :mode-p nano-modeline-elfeed-search-mode-p
                             :format nano-modeline-elfeed-search-mode
                             :on-activate nano-modeline-elfeed-search-activate
                             :on-inactivate nano-modeline-elfeed-search-inactivate
-                            :icon "") ;; nerd-font / oct-search
+                            :icon " ") ;; nerd-font / oct-search
     (elfeed-show-mode       :mode-p nano-modeline-elfeed-show-mode-p
                             :format nano-modeline-elfeed-show-mode
-                            :icon "") ;; nerd-font / oct-comment
+                            :icon " ") ;; nerd-font / oct-comment
     (elpher-mode            :mode-p nano-modeline-elpher-mode-p
                             :format nano-modeline-elpher-mode
                             :on-activate nano-modeline-elpher-activate
-                            :icon "") ;; nerd-font / oct-browser
+                            :icon " ") ;; nerd-font / oct-browser
     (info-mode              :mode-p nano-modeline-info-mode-p
                             :format nano-modeline-info-mode
                             :on-activate nano-modeline-info-activate
                             :on-inactivate nano-modeline-info-inactivate
-                            :icon "") ;; nerd-font / oct-info
+                            :icon " ") ;; nerd-font / oct-info
     (nano-help-mode         :mode-p nano-modeline-nano-help-mode-p
                             :format nano-modeline-nano-help-mode
-                            :icon "") ;; nerd-font / oct-info
+                            :icon " ") ;; nerd-font / oct-info
     (org-agenda-mode        :mode-p nano-modeline-org-agenda-mode-p
                             :format nano-modeline-org-agenda-mode
-                            :icon "") ;; nerd-font / oct-calendar
+                            :icon " ") ;; nerd-font / oct-calendar
     (org-clock-mode         :mode-p nano-modeline-org-clock-mode-p
                             :format nano-modeline-org-clock-mode
                             :on-activate nano-modeline-org-clock-activate
                             :on-inactivate nano-modeline-org-clock-inactivate
-                            :icon "") ;; nerd-font / oct-clock
+                            :icon " ") ;; nerd-font / oct-clock
     (pdf-view-mode          :mode-p nano-modeline-pdf-view-mode-p
                             :format nano-modeline-pdf-view-mode
-                            :icon "") ;; nerd-font/ oct-file-pdf
+                            :icon " ") ;; nerd-font/ oct-file-pdf
 
     ;; hooks only last
     (ein-notebook-mode      :on-activate nano-modeline-ein-notebook-activate
@@ -525,7 +525,7 @@ When return value is \"0\", then the section is hidden"
                             (propertize "- " 'face face-secondary))))))
 	     (right-len (length (format-mode-line right))))
     (concat
-     left 
+     left
      (propertize " "  'face face-secondary
                  'display `(space :align-to (- right
                                                (-1 . right-margin)
@@ -567,7 +567,7 @@ When return value is \"0\", then the section is hidden"
          (no-database (zerop (elfeed-db-last-update)))
          (update      (> (elfeed-queue-count-total) 0))
          (name  (cond (no-database "No database")
-                      (update      "Update:") 
+                      (update      "Update:")
                       (t           "Search:")))
          (primary (cond  (no-database "")
                          (update
@@ -904,7 +904,7 @@ depending on the version of mu4e."
           (branch      (nano-modeline-vc-branch))
           (position    (format-mode-line "%l:%c")))
       (nano-modeline-render (plist-get (cdr (assoc 'org-clock-mode nano-modeline-mode-formats)) :icon)
-                             buffer-name 
+                             buffer-name
                              (concat "(" mode-name
                                      (if branch (concat ", " branch))
                                      ")" )
@@ -1085,7 +1085,7 @@ depending on the version of mu4e."
                             (buffer-narrowed-p)
                             (buffer-base-buffer))
                        (format"%s [%s]" (buffer-base-buffer)
-                              (org-link-display-format 
+                              (org-link-display-format
                               (substring-no-properties (or (org-get-heading 'no-tags)
                                                        "-")))))
                       ((and (buffer-narrowed-p)
@@ -1093,7 +1093,7 @@ depending on the version of mu4e."
                        (format"%s [narrow]" (buffer-base-buffer)))
                       (t
                        (format-mode-line "%b"))))
-        
+
         (mode-name   (nano-modeline-mode-name))
         (branch      (nano-modeline-vc-branch))
         (position    (format-mode-line "%l:%c")))

--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -392,7 +392,7 @@ KEY mode name, for reference only. Easier to do lookups and/or replacements.
   "Return current VC branch if any."
   (if vc-mode
       (let ((backend (vc-backend buffer-file-name)))
-        (concat "#" (substring-no-properties vc-mode
+        (concat " " (substring-no-properties vc-mode
                                  (+ (if (eq backend 'Hg) 2 3) 2))))  nil))
 
 (defun nano-modeline-mode-name ()
@@ -1084,7 +1084,7 @@ depending on the version of mu4e."
         (position    (format-mode-line "%l:%c")))
     (nano-modeline-render icon
                           buffer-name
-                          (if branch (concat "(" branch ")") "")
+                          (if branch (concat " " branch) "")
                           position)))
 
 

--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -160,6 +160,12 @@ Then number is provided by `nano-modeline-tab-number'."
   :type 'boolean
   :group 'nano-modeline)
 
+(defcustom nano-modeline-display-mail-count nil
+  "Whether to display the unread email count in the mode-line.
+Then count is provided by `nano-modeline-email-count'."
+  :type 'boolean
+  :group 'nano-modeline)
+
 (defface nano-modeline-active
   '((t (:inherit mode-line)))
   "Modeline face for active modeline"
@@ -437,6 +443,13 @@ When return value is \"0\", then the section is hidden"
          (if explicit-name tab-name (+ 1 tab-index)))
      (string-to-number "0"))))
 
+(defun nano-modeline-email-count ()
+  "Return the count of unread emails and ad mail icon."
+  (if mu4e-alert-mode-line
+      (concat "  " (progn (string-match "[0-9]+" mu4e-alert-mode-line)
+                           (match-string 0 mu4e-alert-mode-line)) " ")
+    (format "")))
+
 (defun nano-modeline-render (icon name primary secondary &optional status)
   "Compose a string with provided information"
 
@@ -503,6 +516,8 @@ When return value is \"0\", then the section is hidden"
                        (propertize " •" 'face face-secondary)))
                  (propertize " "  'face `(:inherit ,face-modeline)
                                   'display `(raise ,nano-modeline-space-bottom))
+                 (if nano-modeline-display-mail-count
+                    (concat (propertize (nano-modeline-email-count) 'face face-primary)))
                  (if nano-modeline-display-tab-number
                      (if (not (equal "0" (nano-modeline-tab-number)))
                     (concat (propertize " -" 'face face-secondary)

--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -154,6 +154,12 @@ This is useful (aesthetically) if the face of prefix uses a different background
   :type 'boolean
   :group 'nano-modeline)
 
+(defcustom nano-modeline-display-tab-number nil
+  "Whether to display the tab-number in the mode-line.
+Then number is provided by `nano-modeline-tab-number'."
+  :type 'boolean
+  :group 'nano-modeline)
+
 (defface nano-modeline-active
   '((t (:inherit mode-line)))
   "Modeline face for active modeline"
@@ -418,6 +424,19 @@ KEY mode name, for reference only. Easier to do lookups and/or replacements.
             (read-only 'read-only)
             (t         'read-write)))))
 
+(defun nano-modeline-tab-number ()
+  "Return the number of the current tab as a string if there are more than 1 tab open.
+Return \"0\" if there is only on tab open.
+When return value is \"0\", then the section is hidden"
+  (number-to-string
+   (if (length> (frame-parameter nil 'tabs) 1)
+       (let* ((current-tab (tab-bar--current-tab))
+              (tab-index (tab-bar--current-tab-index))
+              (explicit-name (alist-get 'explicit-name current-tab))
+              (tab-name (alist-get 'name current-tab)))
+         (if explicit-name tab-name (+ 1 tab-index)))
+     (string-to-number "0"))))
+
 (defun nano-modeline-render (icon name primary secondary &optional status)
   "Compose a string with provided information"
 
@@ -483,7 +502,12 @@ KEY mode name, for reference only. Easier to do lookups and/or replacements.
                    (if (window-dedicated-p)
                        (propertize " •" 'face face-secondary)))
                  (propertize " "  'face `(:inherit ,face-modeline)
-                                  'display `(raise ,nano-modeline-space-bottom))))
+                                  'display `(raise ,nano-modeline-space-bottom))
+                 (if nano-modeline-display-tab-number
+                     (if (not (equal "0" (nano-modeline-tab-number)))
+                    (concat (propertize " -" 'face face-secondary)
+                            (propertize (nano-modeline-tab-number) 'face face-secondary)
+                            (propertize "- " 'face face-secondary))))))
 	     (right-len (length (format-mode-line right))))
     (concat
      left 

--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -166,6 +166,12 @@ Then count is provided by `nano-modeline-unread-email-count'."
   :type 'boolean
   :group 'nano-modeline)
 
+(defcustom nano-modeline-display-misc-info nil
+  "Whether to display misc-info in the mode-line.
+Then info is provided by `nano-modeline-misc-info'."
+  :type 'boolean
+  :group 'nano-modeline)
+
 (defface nano-modeline-active
   '((t (:inherit mode-line)))
   "Modeline face for active modeline"
@@ -457,6 +463,18 @@ When return value is \"0\", then the section is hidden"
                                   (length mu4e~headers-mode-line-label))))
     (shell-command-to-string (format "echo -n $(mu find %s 2> /dev/null | wc -l)" string))))
 
+(defun nano-modeline-misc-info ()
+  "Return miscellaneous and useful info if the `major-mode' provides these.
+This is similar to the information in `mode-line-misc-info'.
+
+Information:
+- Python Virtual Environment using `pyvenv-virtual-env-name'.
+  The Venv is only shown when active and in a python buffer."
+  (let ((venv (if (and pyvenv-virtual-env-name (eq major-mode 'python-mode))
+                  (format " %s" pyvenv-virtual-env-name)
+                (format ""))))
+    (format venv)))
+
 (defun nano-modeline-render (icon name primary secondary &optional status)
   "Compose a string with provided information"
 
@@ -529,7 +547,11 @@ When return value is \"0\", then the section is hidden"
                      (if (not (equal "0" (nano-modeline-tab-number)))
                     (concat (propertize " -" 'face face-secondary)
                             (propertize (nano-modeline-tab-number) 'face face-secondary)
-                            (propertize "- " 'face face-secondary))))))
+                            (propertize "- " 'face face-secondary))))
+                 (if nano-modeline-display-misc-info
+                     (if (not (equal "" (nano-modeline-misc-info)))
+                    (concat (propertize (nano-modeline-misc-info) 'face face-primary)
+                            (propertize " " 'face face-secondary))))))
 	     (right-len (length (format-mode-line right))))
     (concat
      left


### PR DESCRIPTION
# option:
The number of the current tab is displayed to the right (secondary section) in the form of `-1-`.
This will happen only if:
- tab-bar-mode is enabled
- the custom variable nano-modeline-display-tab-number is set to `t` and
- there are more than 1 tab open

# changes to files:
- nano-modeline.el:
  - Add custom variable nano-modeline-display-tab-number
  - Add function nano-modeline-tab-number
  - Modify function nano-modeline-render