### PR TITLE
Fix nano-modeline--base-face

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -225,7 +225,7 @@ Each face defined here is used by the modeline depending on the current state (a
          (active (eq window nano-modeline--selected-window))
          (state (intern (concat (symbol-name face-prefix)
                                 (if active "-active" "-inactive"))))
-         (face (cdr (assoc state nano-modeline-faces))))
+         (face (cadr (assoc state nano-modeline-faces))))
     face))
 
 (defun nano-modeline-face (&optional face-prefix)


### PR DESCRIPTION
Unless for some reason this function is supposed to return a single item list, I think this should be `cadr`, rather than `cdr`