### PR TITLE
Remove style from box

### DIFF
--- a/nano-modeline.el
+++ b/nano-modeline.el
@@ -162,8 +162,7 @@
        :background ,(face-background 'default)
        :family "Roboto Mono"
        :box (:line-width 2
-             :color ,(face-foreground 'default)
-             :style none)))
+             :color ,(face-foreground 'default))))
   "Active button face")
 
 (defface nano-modeline-button-inactive-face
@@ -171,8 +170,7 @@
        :background ,(face-background 'header-line nil t)
        :family "Roboto Mono"
        :box (:line-width 2
-             :color ,(face-foreground 'default)
-             :style none)))
+             :color ,(face-foreground 'default))))
   "Inactive button face.")
 
 (defface nano-modeline-button-highlight-face


### PR DESCRIPTION
Fixes #67.

I am not sure if this is the best permanent solution, as I don't what was the original intention of setting `:style` to `none`. I *think* this should preserve the same behavior, and work with the latest version of Emacs as well.